### PR TITLE
Fixed Division by zero inside fraction() when neutrinoSupply==0

### DIFF
--- a/script/liquidation.ride
+++ b/script/liquidation.ride
@@ -265,7 +265,7 @@ func liquidateBond() = {
         let finalNBTFillable = fraction(fillableOrderAmountX100, 1, nsbt2UsdnPrice) #bt value
         let fillableOrderAmount = fillableOrderAmountX100 / 100
 
-        let nbTokensLiquidateCondition = fraction(surplus + neutrinoSupply, 100, neutrinoSupply) >= nsbt2UsdnPrice
+        let nbTokensLiquidateCondition = surplus >= fraction(neutrinoSupply, nsbt2UsdnPrice, 100) - neutrinoSupply
 
         if (!nbTokensLiquidateCondition)
             then throw("innapropriate surplus: " + toString(surplus))


### PR DESCRIPTION
In the situation when all the USDN are on the Neutrino and Liquidation contracts, i.e. neutrinoSupply is 0, we'll face division by zero during liquidateBond() invocation. To solve it the expression is converted to mathematically equivalent one